### PR TITLE
refactor: refactored the schema on category delete from the database

### DIFF
--- a/back-end/src/database/schema.sql
+++ b/back-end/src/database/schema.sql
@@ -15,3 +15,10 @@ CREATE TABLE IF NOT EXISTS contacts (
   category_id UUID,
   FOREIGN KEY(category_id) REFERENCES categories(id)
 );
+
+ALTER TABLE IF EXISTS contacts
+  DROP CONSTRAINT contacts_category_id_fkey;
+
+ALTER TABLE IF EXISTS contacts
+  ADD CONSTRAINT category_fk FOREIGN KEY(category_id) REFERENCES categories(id)
+  ON DELETE SET NULL;


### PR DESCRIPTION
when you delete a category that is a foreign key to a contact, the category on the contact is set to NULL